### PR TITLE
Add issuer check to ginjwt

### DIFF
--- a/ginjwt/jwt.go
+++ b/ginjwt/jwt.go
@@ -107,6 +107,19 @@ func (m *Middleware) AuthRequired(scopes []string) gin.HandlerFunc {
 			return
 		}
 
+		// Some OIDC providers tack on a trailing slash to the iss: field even if it isn't
+		// specified. This ensures that the Issuers that are being compared are at least
+		// equivalent.
+		if ok := strings.HasSuffix(cl.Issuer, "/"); ok {
+			if chk := strings.HasSuffix(m.config.Issuer, "/"); !chk {
+				m.config.Issuer += "/"
+			}
+		} else {
+			if chk := strings.HasSuffix(m.config.Issuer, "/"); chk {
+				m.config.Issuer = strings.TrimSuffix(m.config.Issuer, "/")
+			}
+		}
+
 		err = cl.Validate(jwt.Expected{
 			Issuer:   m.config.Issuer,
 			Audience: jwt.Audience{m.config.Audience},


### PR DESCRIPTION
When testing OIDC auth with ginjwt in another project, validation was failing with the following:

```
{"error":"square/go-jose/jwt: validation failed, invalid issuer claim (iss)","message":"invalid auth token"}
```

This was because the issuer field from the JWT had appended a trailing slash to it's issuer (even though it wasn't specified), which did not align with the oidc-issuer that was being specified by the running application. To account for this, I've added a check prior to validation that ensures that if the JWT issuer has a trailing slash, the config issuer should also have a trailing slash (and vice-versa if the JWT issuer doesn't have a trailing slash but the config issuer shouldn't either).