### PR TITLE
Respect enable.oidc flag

### DIFF
--- a/ginjwt/helpers.go
+++ b/ginjwt/helpers.go
@@ -52,6 +52,10 @@ func RegisterViperOIDCFlags(v *viper.Viper, cmd *cobra.Command) {
 func GetAuthConfigFromFlags(v *viper.Viper) (AuthConfig, error) {
 	var issuer, jwkuri string
 
+	if !v.GetBool("oidc.enabled") {
+		return AuthConfig{}, nil
+	}
+
 	givenIssuers := v.GetStringSlice("oidc.issuer")
 	givenJWKURIs := v.GetStringSlice("oidc.jwksuri")
 
@@ -87,6 +91,10 @@ func GetAuthConfigFromFlags(v *viper.Viper) (AuthConfig, error) {
 // Note that this function will retrieve as many AuthConfigs as the number
 // of issuers and JWK URIs given (which must match)
 func GetAuthConfigsFromFlags(v *viper.Viper) ([]AuthConfig, error) {
+	if !v.GetBool("oidc.enabled") {
+		return []AuthConfig{}, nil
+	}
+
 	givenIssuers := v.GetStringSlice("oidc.issuer")
 	givenJWKURIs := v.GetStringSlice("oidc.jwksuri")
 

--- a/ginjwt/helpers_test.go
+++ b/ginjwt/helpers_test.go
@@ -204,6 +204,18 @@ func TestRegisterViperOIDCFlagsForMultipleConfigs(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "Get no AuthConfigs if OIDC is diabled",
+			args: Args{
+				Enabled:       false,
+				Audience:      "",
+				Issuer:        []string{},
+				JWKSURI:       []string{},
+				RolesClaim:    "",
+				UsernameClaim: "",
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tc := range tests {
@@ -228,13 +240,17 @@ func TestRegisterViperOIDCFlagsForMultipleConfigs(t *testing.T) {
 
 			assert.NoError(t, err)
 
-			for idx, gotAT := range gotATs {
-				assert.Equal(t, tc.args.Enabled, gotAT.Enabled)
-				assert.Equal(t, tc.args.Audience, gotAT.Audience)
-				assert.Equal(t, tc.args.Issuer[idx], gotAT.Issuer)
-				assert.Equal(t, tc.args.JWKSURI[idx], gotAT.JWKSURI)
-				assert.Equal(t, tc.args.RolesClaim, gotAT.RolesClaim)
-				assert.Equal(t, tc.args.UsernameClaim, gotAT.UsernameClaim)
+			if v.GetBool("oidc.enabled") {
+				for idx, gotAT := range gotATs {
+					assert.Equal(t, tc.args.Enabled, gotAT.Enabled)
+					assert.Equal(t, tc.args.Audience, gotAT.Audience)
+					assert.Equal(t, tc.args.Issuer[idx], gotAT.Issuer)
+					assert.Equal(t, tc.args.JWKSURI[idx], gotAT.JWKSURI)
+					assert.Equal(t, tc.args.RolesClaim, gotAT.RolesClaim)
+					assert.Equal(t, tc.args.UsernameClaim, gotAT.UsernameClaim)
+				}
+			} else {
+				assert.Empty(t, gotATs)
 			}
 		})
 	}


### PR DESCRIPTION
When getting AuthConfigs from viper configurations, we now respect the
flag that enables/disables oidc. If disabled, no config will be given.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
