### PR TITLE
Multiple oidc providers should be a slice of maps, instead of single field arrays

### DIFF
--- a/ginjwt/errors.go
+++ b/ginjwt/errors.go
@@ -11,7 +11,7 @@ var (
 	// ErrInvalidIssuer is the error returned when the issuer of the token isn't what we expect
 	ErrInvalidIssuer = errors.New("invalid JWT issuer")
 
-	// ErrInvalidAuthconfig is an error returned when the oidc auth config isn't able to be unmarshaled
+	// ErrInvalidAuthConfig is an error returned when the oidc auth config isn't able to be unmarshaled
 	ErrInvalidAuthConfig = errors.New("invalid oidc config provided")
 
 	// ErrMissingAuthConfig is an error returned when the oidc auth config isn't provided via a command line flag.

--- a/ginjwt/errors.go
+++ b/ginjwt/errors.go
@@ -11,13 +11,15 @@ var (
 	// ErrInvalidIssuer is the error returned when the issuer of the token isn't what we expect
 	ErrInvalidIssuer = errors.New("invalid JWT issuer")
 
-	// ErrMissingIssuerFlag is an error eturned when the issuer isn't provided via a command line flag.
+	// ErrInvalidAuthconfig is an error returned when the oidc auth config isn't able to be unmarshaled
+	ErrInvalidAuthConfig = errors.New("invalid oidc config provided")
+
+	// ErrMissingAuthConfig is an error returned when the oidc auth config isn't provided via a command line flag.
+	ErrMissingAuthConfig = errors.New("oidc auth config wasn't provided")
+
+	// ErrMissingIssuerFlag is an error returned when the issuer isn't provided via a command line flag.
 	ErrMissingIssuerFlag = errors.New("issuer wasn't provided")
 
-	// ErrMissingJWKURIFlag is an error eturned when the JWK URI isn't provided via a command line flag.
+	// ErrMissingJWKURIFlag is an error returned when the JWK URI isn't provided via a command line flag.
 	ErrMissingJWKURIFlag = errors.New("JWK URI wasn't provided")
-
-	// ErrIssuersDontMatchJWKURIs is the error returned when the number of issuers given
-	// as command line flags don't match the number of JWK URIs given.
-	ErrIssuersDontMatchJWKURIs = errors.New("the number of issuers doesn't match the number of JWK URIs")
 )

--- a/ginjwt/helpers.go
+++ b/ginjwt/helpers.go
@@ -66,7 +66,6 @@ func RegisterViperOIDCFlags(v *viper.Viper, cmd *cobra.Command) {
 func GetAuthConfigFromFlags(v *viper.Viper) (AuthConfig, error) {
 	var authConfigs []OIDCConfig
 	if err := v.UnmarshalKey("oidc", &authConfigs); err != nil {
-		// backwards compatible to single entry
 		return AuthConfig{}, ErrInvalidAuthConfig
 	}
 

--- a/ginjwt/helpers.go
+++ b/ginjwt/helpers.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-// OIDCConfig provides the configuration for the authentication service
+// OIDCConfig provides the configuration for the oidc provider auth configuration
 type OIDCConfig struct {
 	Enabled  bool   `yaml:"enabled"`
 	Audience string `yaml:"audience"`
@@ -15,6 +15,7 @@ type OIDCConfig struct {
 	Claims   Claims `yaml:"claims"`
 }
 
+// Claims defines the roles and username claims for the given oidc provider
 type Claims struct {
 	Roles    string `yaml:"roles"`
 	Username string `yaml:"username"`
@@ -29,9 +30,28 @@ type Claims struct {
 //
 //		ginjwt.RegisterViperOIDCFlags(viper.GetViper(), serveCmd)
 //
+// The oidc configuration should be passed in through a yaml file due to the nested
+// structure of the fields, however, if only one oidc provider is used the flag parameters would work
+//
+// * `oidc-aud`: Specifies the expected audience for the JWT token
+// * `oidc-issuer`: Specifies the expected issuer for the JWT token (can be more than one value)
+// * `oidc-jwksuri`: Specifies the JSON Web Key Set (JWKS) URI (can be more than one value).
+// * `oidc-roles-claim`: Specifies the roles to be accepted for the JWT claim.
+// * `oidc-username-claim`: Specifies a username to use for the JWT claim
+//
 func RegisterViperOIDCFlags(v *viper.Viper, cmd *cobra.Command) {
 	cmd.Flags().Bool("oidc", true, "use oidc auth")
 	ViperBindFlag("oidc.enabled", cmd.Flags().Lookup("oidc"))
+	cmd.Flags().String("oidc-aud", "", "expected audience on OIDC JWT")
+	ViperBindFlag("oidc.audience", cmd.Flags().Lookup("oidc-aud"))
+	cmd.Flags().StringSlice("oidc-issuer", []string{}, "expected issuer of OIDC JWT")
+	ViperBindFlag("oidc.issuer", cmd.Flags().Lookup("oidc-issuer"))
+	cmd.Flags().StringSlice("oidc-jwksuri", []string{}, "URI for JWKS listing for JWTs")
+	ViperBindFlag("oidc.jwksuri", cmd.Flags().Lookup("oidc-jwksuri"))
+	cmd.Flags().String("oidc-roles-claim", "claim", "field containing the permissions of an OIDC JWT")
+	ViperBindFlag("oidc.claims.roles", cmd.Flags().Lookup("oidc-roles-claim"))
+	cmd.Flags().String("oidc-username-claim", "", "additional fields to output in logs from the JWT token, ex (email)")
+	ViperBindFlag("oidc.claims.username", cmd.Flags().Lookup("oidc-username-claim"))
 }
 
 // GetAuthConfigFromFlags builds an AuthConfig object from flags provided by

--- a/ginjwt/helpers.go
+++ b/ginjwt/helpers.go
@@ -20,11 +20,6 @@ type OIDCConfig struct {
 // have the following command line/configuration flags registered:
 //
 // * `oidc`: Enables/disables OIDC Authentication
-// * `oidc-aud`: Specifies the expected audience for the JWT token
-// * `oidc-issuer`: Specifies the expected issuer for the JWT token (can be more than one value)
-// * `oidc-jwksuri`: Specifies the JSON Web Key Set (JWKS) URI (can be more than one value).
-// * `oidc-roles-claim`: Specifies the roles to be accepted for the JWT claim.
-// * `oidc-username-claim`: Specifies a username to use for the JWT claim
 //
 // A call to this would normally look as follows:
 //

--- a/ginjwt/helpers.go
+++ b/ginjwt/helpers.go
@@ -8,12 +8,16 @@ import (
 
 // OIDCConfig provides the configuration for the authentication service
 type OIDCConfig struct {
-	Enabled       bool   `yaml:"enabled"`
-	Audience      string `yaml:"audience"`
-	Issuer        string `yaml:"issuer"`
-	JWKSURI       string `yaml:"jwsuri"`
-	RolesClaim    string `yaml:"claims.roles"`
-	UsernameClaim string `yaml:"claims.user"`
+	Enabled  bool   `yaml:"enabled"`
+	Audience string `yaml:"audience"`
+	Issuer   string `yaml:"issuer"`
+	JWKSURI  string `yaml:"jwsuri"`
+	Claims   Claims `yaml:"claims"`
+}
+
+type Claims struct {
+	Roles    string `yaml:"roles"`
+	Username string `yaml:"username"`
 }
 
 // RegisterViperOIDCFlags ensures that the given Viper and cobra.Command instances
@@ -43,12 +47,7 @@ func GetAuthConfigFromFlags(v *viper.Viper) (AuthConfig, error) {
 	var authConfigs []OIDCConfig
 	if err := v.UnmarshalKey("oidc", &authConfigs); err != nil {
 		// backwards compatible to single entry
-		var ac OIDCConfig
-		if err := v.UnmarshalKey("oidc", &ac); err != nil {
-			return AuthConfig{}, ErrInvalidAuthConfig
-		}
-		// Append single config to what would be an empty list
-		authConfigs = append(authConfigs, ac)
+		return AuthConfig{}, ErrInvalidAuthConfig
 	}
 
 	if len(authConfigs) == 0 {
@@ -74,8 +73,8 @@ func GetAuthConfigFromFlags(v *viper.Viper) (AuthConfig, error) {
 		Audience:      config.Audience,
 		Issuer:        config.Issuer,
 		JWKSURI:       config.JWKSURI,
-		RolesClaim:    config.RolesClaim,
-		UsernameClaim: config.UsernameClaim,
+		RolesClaim:    config.Claims.Roles,
+		UsernameClaim: config.Claims.Username,
 	}, nil
 }
 
@@ -117,8 +116,8 @@ func GetAuthConfigsFromFlags(v *viper.Viper) ([]AuthConfig, error) {
 					Audience:      c.Audience,
 					Issuer:        c.Issuer,
 					JWKSURI:       c.JWKSURI,
-					RolesClaim:    c.RolesClaim,
-					UsernameClaim: c.UsernameClaim,
+					RolesClaim:    c.Claims.Roles,
+					UsernameClaim: c.Claims.Username,
 				},
 			)
 		}

--- a/ginjwt/helpers_test.go
+++ b/ginjwt/helpers_test.go
@@ -13,53 +13,61 @@ import (
 func TestRegisterViperOIDCFlags(t *testing.T) {
 	tests := []struct {
 		name               string
-		expectedAuthConfig ginjwt.AuthConfig
+		expectedAuthConfig []ginjwt.OIDCConfig
 		wantErr            bool
 	}{
 		{
 			name: "Get AuthConfig from parameters scenario 1",
-			expectedAuthConfig: ginjwt.AuthConfig{
-				Enabled:       true,
-				Audience:      "tacos",
-				Issuer:        "are",
-				JWKSURI:       "https://bit.ly/3HlVmWp",
-				RolesClaim:    "pretty",
-				UsernameClaim: "awesome",
+			expectedAuthConfig: []ginjwt.OIDCConfig{
+				{
+					Enabled:       true,
+					Audience:      "tacos",
+					Issuer:        "are",
+					JWKSURI:       "https://bit.ly/3HlVmWp",
+					RolesClaim:    "pretty",
+					UsernameClaim: "awesome",
+				},
 			},
 		},
 		{
 			name: "Get AuthConfig from parameters scenario 2",
-			expectedAuthConfig: ginjwt.AuthConfig{
-				Enabled:       true,
-				Audience:      "beer",
-				Issuer:        "is",
-				JWKSURI:       "https://bit.ly/3HlVmWp",
-				RolesClaim:    "quite",
-				UsernameClaim: "tasty",
+			expectedAuthConfig: []ginjwt.OIDCConfig{
+				{
+					Enabled:       true,
+					Audience:      "beer",
+					Issuer:        "is",
+					JWKSURI:       "https://bit.ly/3HlVmWp",
+					RolesClaim:    "quite",
+					UsernameClaim: "tasty",
+				},
 			},
 		},
 		{
 			name: "Get AuthConfig fails due to missing issuer",
-			expectedAuthConfig: ginjwt.AuthConfig{
-				Enabled:       true,
-				Audience:      "beer",
-				Issuer:        "",
-				JWKSURI:       "https://bit.ly/3HlVmWp",
-				RolesClaim:    "quite",
-				UsernameClaim: "tasty",
+			expectedAuthConfig: []ginjwt.OIDCConfig{
+				{
+					Enabled:       true,
+					Audience:      "beer",
+					Issuer:        "",
+					JWKSURI:       "https://bit.ly/3HlVmWp",
+					RolesClaim:    "quite",
+					UsernameClaim: "tasty",
+				},
 			},
 			wantErr: true,
 		},
 
 		{
 			name: "Get AuthConfig fails due to missing JWK URI",
-			expectedAuthConfig: ginjwt.AuthConfig{
-				Enabled:       true,
-				Audience:      "beer",
-				Issuer:        "is",
-				JWKSURI:       "",
-				RolesClaim:    "quite",
-				UsernameClaim: "tasty",
+			expectedAuthConfig: []ginjwt.OIDCConfig{
+				{
+					Enabled:       true,
+					Audience:      "beer",
+					Issuer:        "is",
+					JWKSURI:       "",
+					RolesClaim:    "quite",
+					UsernameClaim: "tasty",
+				},
 			},
 			wantErr: true,
 		},
@@ -71,16 +79,7 @@ func TestRegisterViperOIDCFlags(t *testing.T) {
 
 			ginjwt.RegisterViperOIDCFlags(v, cmd)
 
-			v.Set("oidc.enabled", tc.expectedAuthConfig.Enabled)
-			v.Set("oidc.audience", tc.expectedAuthConfig.Audience)
-			if tc.expectedAuthConfig.Issuer != "" {
-				v.Set("oidc.issuer", []string{tc.expectedAuthConfig.Issuer})
-			}
-			if tc.expectedAuthConfig.JWKSURI != "" {
-				v.Set("oidc.jwksuri", []string{tc.expectedAuthConfig.JWKSURI})
-			}
-			v.Set("oidc.claims.roles", tc.expectedAuthConfig.RolesClaim)
-			v.Set("oidc.claims.username", tc.expectedAuthConfig.UsernameClaim)
+			v.Set("oidc", tc.expectedAuthConfig)
 
 			gotAT, err := ginjwt.GetAuthConfigFromFlags(v)
 			if tc.wantErr {
@@ -88,42 +87,35 @@ func TestRegisterViperOIDCFlags(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 
-				assert.Equal(t, tc.expectedAuthConfig.Enabled, gotAT.Enabled)
-				assert.Equal(t, tc.expectedAuthConfig.Audience, gotAT.Audience)
-				assert.Equal(t, tc.expectedAuthConfig.Issuer, gotAT.Issuer)
-				assert.Equal(t, tc.expectedAuthConfig.JWKSURI, gotAT.JWKSURI)
-				assert.Equal(t, tc.expectedAuthConfig.RolesClaim, gotAT.RolesClaim)
-				assert.Equal(t, tc.expectedAuthConfig.UsernameClaim, gotAT.UsernameClaim)
+				assert.Equal(t, tc.expectedAuthConfig[0].Enabled, gotAT.Enabled)
+				assert.Equal(t, tc.expectedAuthConfig[0].Audience, gotAT.Audience)
+				assert.Equal(t, tc.expectedAuthConfig[0].Issuer, gotAT.Issuer)
+				assert.Equal(t, tc.expectedAuthConfig[0].JWKSURI, gotAT.JWKSURI)
+				assert.Equal(t, tc.expectedAuthConfig[0].RolesClaim, gotAT.RolesClaim)
+				assert.Equal(t, tc.expectedAuthConfig[0].UsernameClaim, gotAT.UsernameClaim)
 			}
 		})
 	}
 }
 
 func TestRegisterViperOIDCFlagsForMultipleConfigs(t *testing.T) {
-	type Args struct {
-		Enabled       bool
-		Audience      string
-		Issuer        []string
-		JWKSURI       []string
-		RolesClaim    string
-		UsernameClaim string
-	}
-
 	tests := []struct {
 		name                string
-		args                Args
+		config              []ginjwt.OIDCConfig
 		expectedAuthConfigs []ginjwt.AuthConfig
 		wantErr             bool
 	}{
 		{
 			name: "Get AuthConfig from parameters with one issuer and JWK URI",
-			args: Args{
-				Enabled:       true,
-				Audience:      "tacos",
-				Issuer:        []string{"are"},
-				JWKSURI:       []string{"https://bit.ly/3HlVmWp"},
-				RolesClaim:    "pretty",
-				UsernameClaim: "awesome",
+			config: []ginjwt.OIDCConfig{
+				{
+					Enabled:       true,
+					Audience:      "tacos",
+					Issuer:        "are",
+					JWKSURI:       "https://bit.ly/3HlVmWp",
+					RolesClaim:    "pretty",
+					UsernameClaim: "awesome",
+				},
 			},
 			expectedAuthConfigs: []ginjwt.AuthConfig{
 				{
@@ -137,17 +129,24 @@ func TestRegisterViperOIDCFlagsForMultipleConfigs(t *testing.T) {
 			},
 		},
 		{
-			name: "Get AuthConfig from parameters with two issuers and JWK URIs",
-			args: Args{
-				Enabled:  true,
-				Audience: "Hey Jude",
-				Issuer:   []string{"don't make it bad", "don't be afraid"},
-				JWKSURI: []string{
-					"take a sad song and make it better",
-					"You were made to go out and get her",
+			name: "Get AuthConfig from parameters with two valid configs",
+			config: []ginjwt.OIDCConfig{
+				{
+					Enabled:       true,
+					Audience:      "Hey Jude",
+					Issuer:        "don't make it bad",
+					JWKSURI:       "take a sad song and make it better",
+					RolesClaim:    "Na na na nananana",
+					UsernameClaim: "nannana, hey Jude...",
 				},
-				RolesClaim:    "Na na na nananana",
-				UsernameClaim: "nannana, hey Jude...",
+				{
+					Enabled:       true,
+					Audience:      "Hey Jude",
+					Issuer:        "don't be afraid",
+					JWKSURI:       "You were made to go out and get her",
+					RolesClaim:    "Na na na nananana",
+					UsernameClaim: "nannana, hey Jude...",
+				},
 			},
 			expectedAuthConfigs: []ginjwt.AuthConfig{
 				{
@@ -170,49 +169,43 @@ func TestRegisterViperOIDCFlagsForMultipleConfigs(t *testing.T) {
 		},
 		{
 			name: "Get AuthConfig fails due to missing issuer",
-			args: Args{
-				Enabled:       true,
-				Audience:      "beer",
-				Issuer:        []string{},
-				JWKSURI:       []string{"https://bit.ly/3HlVmWp"},
-				RolesClaim:    "quite",
-				UsernameClaim: "tasty",
+			config: []ginjwt.OIDCConfig{
+				{
+					Enabled:       true,
+					Audience:      "beer",
+					Issuer:        "",
+					JWKSURI:       "https://bit.ly/3HlVmWp",
+					RolesClaim:    "quite",
+					UsernameClaim: "tasty",
+				},
 			},
 			wantErr: true,
 		},
 		{
 			name: "Get AuthConfig fails due to missing JWK URI",
-			args: Args{
-				Enabled:       true,
-				Audience:      "beer",
-				Issuer:        []string{"is"},
-				JWKSURI:       nil,
-				RolesClaim:    "quite",
-				UsernameClaim: "tasty",
-			},
-			wantErr: true,
-		},
-		{
-			name: "Get AuthConfig fails due to missing number of issuers not matching number of JWK URIs",
-			args: Args{
-				Enabled:       true,
-				Audience:      "nana",
-				Issuer:        []string{"nana", "nana", "nana"},
-				JWKSURI:       []string{"nana"},
-				RolesClaim:    "nana na...",
-				UsernameClaim: "BATMAN!",
+			config: []ginjwt.OIDCConfig{
+				{
+					Enabled:       true,
+					Audience:      "beer",
+					Issuer:        "is",
+					JWKSURI:       "",
+					RolesClaim:    "quite",
+					UsernameClaim: "tasty",
+				},
 			},
 			wantErr: true,
 		},
 		{
 			name: "Get no AuthConfigs if OIDC is diabled",
-			args: Args{
-				Enabled:       false,
-				Audience:      "",
-				Issuer:        []string{},
-				JWKSURI:       []string{},
-				RolesClaim:    "",
-				UsernameClaim: "",
+			config: []ginjwt.OIDCConfig{
+				{
+					Enabled:       false,
+					Audience:      "",
+					Issuer:        "",
+					JWKSURI:       "",
+					RolesClaim:    "",
+					UsernameClaim: "",
+				},
 			},
 			wantErr: false,
 		},
@@ -225,14 +218,9 @@ func TestRegisterViperOIDCFlagsForMultipleConfigs(t *testing.T) {
 
 			ginjwt.RegisterViperOIDCFlags(v, cmd)
 
-			v.Set("oidc.enabled", tc.args.Enabled)
-			v.Set("oidc.audience", tc.args.Audience)
-			v.Set("oidc.issuer", tc.args.Issuer)
-			v.Set("oidc.jwksuri", tc.args.JWKSURI)
-			v.Set("oidc.claims.roles", tc.args.RolesClaim)
-			v.Set("oidc.claims.username", tc.args.UsernameClaim)
+			v.Set("oidc", tc.config)
 
-			gotATs, err := ginjwt.GetAuthConfigsFromFlags(v)
+			gotACs, err := ginjwt.GetAuthConfigsFromFlags(v)
 			if tc.wantErr {
 				assert.Error(t, err)
 				return
@@ -240,17 +228,13 @@ func TestRegisterViperOIDCFlagsForMultipleConfigs(t *testing.T) {
 
 			assert.NoError(t, err)
 
-			if v.GetBool("oidc.enabled") {
-				for idx, gotAT := range gotATs {
-					assert.Equal(t, tc.args.Enabled, gotAT.Enabled)
-					assert.Equal(t, tc.args.Audience, gotAT.Audience)
-					assert.Equal(t, tc.args.Issuer[idx], gotAT.Issuer)
-					assert.Equal(t, tc.args.JWKSURI[idx], gotAT.JWKSURI)
-					assert.Equal(t, tc.args.RolesClaim, gotAT.RolesClaim)
-					assert.Equal(t, tc.args.UsernameClaim, gotAT.UsernameClaim)
-				}
-			} else {
-				assert.Empty(t, gotATs)
+			for idx, ac := range gotACs {
+				assert.Equal(t, tc.config[idx].Enabled, ac.Enabled)
+				assert.Equal(t, tc.config[idx].Audience, ac.Audience)
+				assert.Equal(t, tc.config[idx].Issuer, ac.Issuer)
+				assert.Equal(t, tc.config[idx].JWKSURI, ac.JWKSURI)
+				assert.Equal(t, tc.config[idx].RolesClaim, ac.RolesClaim)
+				assert.Equal(t, tc.config[idx].UsernameClaim, ac.UsernameClaim)
 			}
 		})
 	}

--- a/ginjwt/helpers_test.go
+++ b/ginjwt/helpers_test.go
@@ -10,15 +10,97 @@ import (
 	"go.hollow.sh/toolbox/ginjwt"
 )
 
-func TestRegisterViperOIDCFlags(t *testing.T) {
+func TestRegisterViperOIDCFlagsSingleProvider(t *testing.T) {
 	tests := []struct {
 		name               string
-		expectedAuthConfig []ginjwt.OIDCConfig
+		expectedAuthConfig ginjwt.AuthConfig
 		wantErr            bool
 	}{
 		{
 			name: "Get AuthConfig from parameters scenario 1",
-			expectedAuthConfig: []ginjwt.OIDCConfig{
+			expectedAuthConfig: ginjwt.AuthConfig{
+
+				Enabled:       true,
+				Audience:      "tacos",
+				Issuer:        "are",
+				JWKSURI:       "https://bit.ly/3HlVmWp",
+				RolesClaim:    "pretty",
+				UsernameClaim: "awesome",
+			},
+		},
+		{
+			name: "Get AuthConfig from parameters scenario 2",
+			expectedAuthConfig: ginjwt.AuthConfig{
+
+				Enabled:       true,
+				Audience:      "beer",
+				Issuer:        "is",
+				JWKSURI:       "https://bit.ly/3HlVmWp",
+				RolesClaim:    "quite",
+				UsernameClaim: "tasty",
+			},
+		},
+		{
+			name: "Get AuthConfig fails due to missing issuer",
+			expectedAuthConfig: ginjwt.AuthConfig{
+				Enabled:       true,
+				Audience:      "beer",
+				Issuer:        "",
+				JWKSURI:       "https://bit.ly/3HlVmWp",
+				RolesClaim:    "quite",
+				UsernameClaim: "tasty",
+			},
+			wantErr: true,
+		},
+
+		{
+			name: "Get AuthConfig fails due to missing JWK URI",
+			expectedAuthConfig: ginjwt.AuthConfig{
+				Enabled:       true,
+				Audience:      "beer",
+				Issuer:        "is",
+				JWKSURI:       "",
+				RolesClaim:    "quite",
+				UsernameClaim: "tasty",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v := viper.New()
+			cmd := &cobra.Command{}
+
+			ginjwt.RegisterViperOIDCFlags(v, cmd)
+
+			v.Set("oidc", tc.expectedAuthConfig)
+
+			gotAT, err := ginjwt.GetAuthConfigFromFlags(v)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+
+				assert.Equal(t, tc.expectedAuthConfig.Enabled, gotAT.Enabled)
+				assert.Equal(t, tc.expectedAuthConfig.Audience, gotAT.Audience)
+				assert.Equal(t, tc.expectedAuthConfig.Issuer, gotAT.Issuer)
+				assert.Equal(t, tc.expectedAuthConfig.JWKSURI, gotAT.JWKSURI)
+				assert.Equal(t, tc.expectedAuthConfig.RolesClaim, gotAT.RolesClaim)
+				assert.Equal(t, tc.expectedAuthConfig.UsernameClaim, gotAT.UsernameClaim)
+			}
+		})
+	}
+}
+
+func TestRegisterViperOIDCFlags(t *testing.T) {
+	tests := []struct {
+		name               string
+		expectedAuthConfig []ginjwt.AuthConfig
+		wantErr            bool
+	}{
+		{
+			name: "Get AuthConfig from parameters scenario 1",
+			expectedAuthConfig: []ginjwt.AuthConfig{
 				{
 					Enabled:       true,
 					Audience:      "tacos",
@@ -31,7 +113,7 @@ func TestRegisterViperOIDCFlags(t *testing.T) {
 		},
 		{
 			name: "Get AuthConfig from parameters scenario 2",
-			expectedAuthConfig: []ginjwt.OIDCConfig{
+			expectedAuthConfig: []ginjwt.AuthConfig{
 				{
 					Enabled:       true,
 					Audience:      "beer",
@@ -44,7 +126,7 @@ func TestRegisterViperOIDCFlags(t *testing.T) {
 		},
 		{
 			name: "Get AuthConfig fails due to missing issuer",
-			expectedAuthConfig: []ginjwt.OIDCConfig{
+			expectedAuthConfig: []ginjwt.AuthConfig{
 				{
 					Enabled:       true,
 					Audience:      "beer",
@@ -59,7 +141,7 @@ func TestRegisterViperOIDCFlags(t *testing.T) {
 
 		{
 			name: "Get AuthConfig fails due to missing JWK URI",
-			expectedAuthConfig: []ginjwt.OIDCConfig{
+			expectedAuthConfig: []ginjwt.AuthConfig{
 				{
 					Enabled:       true,
 					Audience:      "beer",
@@ -101,13 +183,13 @@ func TestRegisterViperOIDCFlags(t *testing.T) {
 func TestRegisterViperOIDCFlagsForMultipleConfigs(t *testing.T) {
 	tests := []struct {
 		name                string
-		config              []ginjwt.OIDCConfig
+		config              []ginjwt.AuthConfig
 		expectedAuthConfigs []ginjwt.AuthConfig
 		wantErr             bool
 	}{
 		{
 			name: "Get AuthConfig from parameters with one issuer and JWK URI",
-			config: []ginjwt.OIDCConfig{
+			config: []ginjwt.AuthConfig{
 				{
 					Enabled:       true,
 					Audience:      "tacos",
@@ -130,7 +212,7 @@ func TestRegisterViperOIDCFlagsForMultipleConfigs(t *testing.T) {
 		},
 		{
 			name: "Get AuthConfig from parameters with two valid configs",
-			config: []ginjwt.OIDCConfig{
+			config: []ginjwt.AuthConfig{
 				{
 					Enabled:       true,
 					Audience:      "Hey Jude",
@@ -169,7 +251,7 @@ func TestRegisterViperOIDCFlagsForMultipleConfigs(t *testing.T) {
 		},
 		{
 			name: "Get AuthConfig fails due to missing issuer",
-			config: []ginjwt.OIDCConfig{
+			config: []ginjwt.AuthConfig{
 				{
 					Enabled:       true,
 					Audience:      "beer",
@@ -183,7 +265,7 @@ func TestRegisterViperOIDCFlagsForMultipleConfigs(t *testing.T) {
 		},
 		{
 			name: "Get AuthConfig fails due to missing JWK URI",
-			config: []ginjwt.OIDCConfig{
+			config: []ginjwt.AuthConfig{
 				{
 					Enabled:       true,
 					Audience:      "beer",
@@ -197,7 +279,7 @@ func TestRegisterViperOIDCFlagsForMultipleConfigs(t *testing.T) {
 		},
 		{
 			name: "Get no AuthConfigs if OIDC is diabled",
-			config: []ginjwt.OIDCConfig{
+			config: []ginjwt.AuthConfig{
 				{
 					Enabled:       false,
 					Audience:      "",


### PR DESCRIPTION
Tested with the archetype-service by adding a `.archetypeservice.yaml` and running

```
go run main.go serve --debug --pretty --config=.archetypeservice.yaml
```

With multiple `oidc` entries, these were all configured and the app started as expected. Example config will now look like: 

```
---
oidc:
- audience: "https://archetype-service.equinixmetal.net"
  issuer: https://hydra.iam.equinixmetal.net/
  jwksuri: https://hydra.edge-a.dc10.metalkube.net/.well-known/jwks.json
  rolesClaim: scope
  enabled: true
- audience: "https://archetype-service.equinixmetal.net"
  issuer: https://auth.equinixmetal.com/
  jwksuri: https://auth.equinixmetal.com/.well-known/jwks.json
  rolesClaim: scp
  enabled: true
```

However, the existing setup should still work as well
