### PR TITLE
Update hasScope to check for all needed scopes in JWT

### DIFF
--- a/ginjwt/jwt.go
+++ b/ginjwt/jwt.go
@@ -260,18 +260,24 @@ func (m *Middleware) getJWKS(kid string) *jose.JSONWebKey {
 }
 
 func hasScope(have, needed []string) bool {
-	neededMap := make(map[string]bool)
-	for _, s := range needed {
-		neededMap[s] = true
+	// Short circuit: If we don't need any scopes, we're good. Return true
+	if len(needed) == 0 {
+		return true
 	}
 
+	haveMap := make(map[string]struct{})
 	for _, s := range have {
-		if neededMap[s] {
-			return true
+		haveMap[s] = struct{}{}
+	}
+
+	// Check the scopes we need against what we have. If any are missing, return false
+	for _, s := range needed {
+		if _, ok := haveMap[s]; !ok {
+			return false
 		}
 	}
 
-	return false
+	return true
 }
 
 // GetSubject will return the JWT subject that is saved in the request. This requires that authentication of the request


### PR DESCRIPTION
As written, `hasScope` returns true if any of the needed scopes are present in the JWT. This appears to be a bug: `Middleware.RequiredScopes` documentation indicates that the provided list of scopes should be present in the role claim in the JWT.

This PR updates `hasScope` to iterate over all needed scopes and fail if any one is not present in the JWT's role claim.