### PR TITLE
Automatically generate release if a semver tag is pushed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v**
+
+jobs:
+  auto-release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true


### PR DESCRIPTION
This detects tags that start with `v` (hopefully semver) and
automatically creates a release (with release notes) that will be
published for this package.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
