### PR TITLE
Configurable role validation strategy

### DIFF
--- a/ginjwt/helpers.go
+++ b/ginjwt/helpers.go
@@ -10,12 +10,13 @@ import (
 
 // OIDCConfig provides the configuration for the oidc provider auth configuration
 type OIDCConfig struct {
-	Enabled           bool          `yaml:"enabled"`
-	Audience          string        `yaml:"audience"`
-	Issuer            string        `yaml:"issuer"`
-	JWKSURI           string        `yaml:"jwsuri"`
-	JWKSRemoteTimeout time.Duration `yaml:"jwksremotetimeout"`
-	Claims            Claims        `yaml:"claims"`
+	Enabled                bool                   `yaml:"enabled"`
+	Audience               string                 `yaml:"audience"`
+	Issuer                 string                 `yaml:"issuer"`
+	JWKSURI                string                 `yaml:"jwsuri"`
+	JWKSRemoteTimeout      time.Duration          `yaml:"jwksremotetimeout"`
+	RoleValidationStrategy RoleValidationStrategy `yaml:"rolevalidationstrategy"`
+	Claims                 Claims                 `yaml:"claims"`
 }
 
 // Claims defines the roles and username claims for the given oidc provider
@@ -58,6 +59,8 @@ func RegisterViperOIDCFlags(v *viper.Viper, cmd *cobra.Command) {
 	ViperBindFlag("oidc.claims.username", cmd.Flags().Lookup("oidc-username-claim"))
 	cmd.Flags().Duration("oidc-jwks-remote-timeout", 1*time.Minute, "timeout for remote JWKS fetching")
 	ViperBindFlag("oidc.jwksremotetimeout", cmd.Flags().Lookup("oidc-jwks-remote-timeout"))
+	cmd.Flags().String("oidc-role-validation-strategy", string(RoleValidationStrategyAny), "validation strategy for roles (any or all)")
+	ViperBindFlag("oidc.rolevalidationstrategy", cmd.Flags().Lookup("oidc-role-validation-strategy"))
 }
 
 // GetAuthConfigFromFlags builds an AuthConfig object from flags provided by
@@ -94,13 +97,14 @@ func GetAuthConfigFromFlags(v *viper.Viper) (AuthConfig, error) {
 	}
 
 	return AuthConfig{
-		Enabled:           config.Enabled,
-		Audience:          config.Audience,
-		Issuer:            config.Issuer,
-		JWKSURI:           config.JWKSURI,
-		JWKSRemoteTimeout: config.JWKSRemoteTimeout,
-		RolesClaim:        config.Claims.Roles,
-		UsernameClaim:     config.Claims.Username,
+		Enabled:                config.Enabled,
+		Audience:               config.Audience,
+		Issuer:                 config.Issuer,
+		JWKSURI:                config.JWKSURI,
+		JWKSRemoteTimeout:      config.JWKSRemoteTimeout,
+		RoleValidationStrategy: config.RoleValidationStrategy,
+		RolesClaim:             config.Claims.Roles,
+		UsernameClaim:          config.Claims.Username,
 	}, nil
 }
 
@@ -138,13 +142,14 @@ func GetAuthConfigsFromFlags(v *viper.Viper) ([]AuthConfig, error) {
 
 			authcfgs = append(authcfgs,
 				AuthConfig{
-					Enabled:           c.Enabled,
-					Audience:          c.Audience,
-					Issuer:            c.Issuer,
-					JWKSURI:           c.JWKSURI,
-					JWKSRemoteTimeout: c.JWKSRemoteTimeout,
-					RolesClaim:        c.Claims.Roles,
-					UsernameClaim:     c.Claims.Username,
+					Enabled:                c.Enabled,
+					Audience:               c.Audience,
+					Issuer:                 c.Issuer,
+					JWKSURI:                c.JWKSURI,
+					JWKSRemoteTimeout:      c.JWKSRemoteTimeout,
+					RoleValidationStrategy: c.RoleValidationStrategy,
+					RolesClaim:             c.Claims.Roles,
+					UsernameClaim:          c.Claims.Username,
 				},
 			)
 		}

--- a/ginjwt/helpers_test.go
+++ b/ginjwt/helpers_test.go
@@ -20,25 +20,27 @@ func TestRegisterViperOIDCFlagsSingleProvider(t *testing.T) {
 		{
 			name: "Get AuthConfig from parameters scenario 1",
 			expectedAuthConfig: ginjwt.AuthConfig{
-				Enabled:           true,
-				Audience:          "tacos",
-				Issuer:            "are",
-				JWKSURI:           "https://bit.ly/3HlVmWp",
-				JWKSRemoteTimeout: 10 * time.Second,
-				RolesClaim:        "pretty",
-				UsernameClaim:     "awesome",
+				Enabled:                true,
+				Audience:               "tacos",
+				Issuer:                 "are",
+				JWKSURI:                "https://bit.ly/3HlVmWp",
+				JWKSRemoteTimeout:      10 * time.Second,
+				RolesClaim:             "pretty",
+				UsernameClaim:          "awesome",
+				RoleValidationStrategy: ginjwt.RoleValidationStrategyAny,
 			},
 		},
 		{
 			name: "Get AuthConfig from parameters scenario 2",
 			expectedAuthConfig: ginjwt.AuthConfig{
-				Enabled:           true,
-				Audience:          "beer",
-				Issuer:            "is",
-				JWKSURI:           "https://bit.ly/3HlVmWp",
-				JWKSRemoteTimeout: 11 * time.Second,
-				RolesClaim:        "quite",
-				UsernameClaim:     "tasty",
+				Enabled:                true,
+				Audience:               "beer",
+				Issuer:                 "is",
+				JWKSURI:                "https://bit.ly/3HlVmWp",
+				JWKSRemoteTimeout:      11 * time.Second,
+				RolesClaim:             "quite",
+				UsernameClaim:          "tasty",
+				RoleValidationStrategy: ginjwt.RoleValidationStrategyAll,
 			},
 		},
 		{
@@ -82,6 +84,7 @@ func TestRegisterViperOIDCFlagsSingleProvider(t *testing.T) {
 			v.Set("oidc.claims.roles", tc.expectedAuthConfig.RolesClaim)
 			v.Set("oidc.claims.username", tc.expectedAuthConfig.UsernameClaim)
 			v.Set("oidc.jwksremotetimeout", tc.expectedAuthConfig.JWKSRemoteTimeout)
+			v.Set("oidc.rolevalidationstrategy", tc.expectedAuthConfig.RoleValidationStrategy)
 
 			gotAT, err := ginjwt.GetAuthConfigFromFlags(v)
 			if tc.wantErr {
@@ -95,6 +98,7 @@ func TestRegisterViperOIDCFlagsSingleProvider(t *testing.T) {
 				assert.Equal(t, tc.expectedAuthConfig.JWKSRemoteTimeout, gotAT.JWKSRemoteTimeout)
 				assert.Equal(t, tc.expectedAuthConfig.RolesClaim, gotAT.RolesClaim)
 				assert.Equal(t, tc.expectedAuthConfig.UsernameClaim, gotAT.UsernameClaim)
+				assert.Equal(t, tc.expectedAuthConfig.RoleValidationStrategy, gotAT.RoleValidationStrategy)
 			}
 		})
 	}
@@ -111,11 +115,12 @@ func TestRegisterViperOIDCFlags(t *testing.T) {
 			name: "Get AuthConfig from parameters scenario 1",
 			config: []ginjwt.OIDCConfig{
 				{
-					Enabled:           true,
-					Audience:          "tacos",
-					Issuer:            "are",
-					JWKSURI:           "https://bit.ly/3HlVmWp",
-					JWKSRemoteTimeout: 10 * time.Second,
+					Enabled:                true,
+					Audience:               "tacos",
+					Issuer:                 "are",
+					JWKSURI:                "https://bit.ly/3HlVmWp",
+					JWKSRemoteTimeout:      10 * time.Second,
+					RoleValidationStrategy: ginjwt.RoleValidationStrategyAny,
 					Claims: ginjwt.Claims{
 						Roles:    "pretty",
 						Username: "awesome",
@@ -124,13 +129,14 @@ func TestRegisterViperOIDCFlags(t *testing.T) {
 			},
 			expectedAuthConfig: []ginjwt.AuthConfig{
 				{
-					Enabled:           true,
-					Audience:          "tacos",
-					Issuer:            "are",
-					JWKSURI:           "https://bit.ly/3HlVmWp",
-					JWKSRemoteTimeout: 10 * time.Second,
-					RolesClaim:        "pretty",
-					UsernameClaim:     "awesome",
+					Enabled:                true,
+					Audience:               "tacos",
+					Issuer:                 "are",
+					JWKSURI:                "https://bit.ly/3HlVmWp",
+					JWKSRemoteTimeout:      10 * time.Second,
+					RolesClaim:             "pretty",
+					UsernameClaim:          "awesome",
+					RoleValidationStrategy: ginjwt.RoleValidationStrategyAny,
 				},
 			},
 		},
@@ -138,11 +144,12 @@ func TestRegisterViperOIDCFlags(t *testing.T) {
 			name: "Get AuthConfig from parameters scenario 2",
 			config: []ginjwt.OIDCConfig{
 				{
-					Enabled:           true,
-					Audience:          "beer",
-					Issuer:            "is",
-					JWKSURI:           "https://bit.ly/3HlVmWp",
-					JWKSRemoteTimeout: 11 * time.Second,
+					Enabled:                true,
+					Audience:               "beer",
+					Issuer:                 "is",
+					JWKSURI:                "https://bit.ly/3HlVmWp",
+					JWKSRemoteTimeout:      11 * time.Second,
+					RoleValidationStrategy: ginjwt.RoleValidationStrategyAll,
 					Claims: ginjwt.Claims{
 						Roles:    "quite",
 						Username: "tasty",
@@ -151,13 +158,14 @@ func TestRegisterViperOIDCFlags(t *testing.T) {
 			},
 			expectedAuthConfig: []ginjwt.AuthConfig{
 				{
-					Enabled:           true,
-					Audience:          "beer",
-					Issuer:            "is",
-					JWKSURI:           "https://bit.ly/3HlVmWp",
-					JWKSRemoteTimeout: 11 * time.Second,
-					RolesClaim:        "quite",
-					UsernameClaim:     "tasty",
+					Enabled:                true,
+					Audience:               "beer",
+					Issuer:                 "is",
+					JWKSURI:                "https://bit.ly/3HlVmWp",
+					JWKSRemoteTimeout:      11 * time.Second,
+					RolesClaim:             "quite",
+					UsernameClaim:          "tasty",
+					RoleValidationStrategy: ginjwt.RoleValidationStrategyAll,
 				},
 			},
 		},
@@ -304,6 +312,7 @@ func TestRegisterViperOIDCFlags(t *testing.T) {
 				assert.Equal(t, tc.expectedAuthConfig[0].JWKSRemoteTimeout, gotAT.JWKSRemoteTimeout)
 				assert.Equal(t, tc.expectedAuthConfig[0].RolesClaim, gotAT.RolesClaim)
 				assert.Equal(t, tc.expectedAuthConfig[0].UsernameClaim, gotAT.UsernameClaim)
+				assert.Equal(t, tc.expectedAuthConfig[0].RoleValidationStrategy, gotAT.RoleValidationStrategy)
 			}
 		})
 	}

--- a/go.sum
+++ b/go.sum
@@ -93,7 +93,6 @@ github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
-github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -371,8 +370,6 @@ github.com/spf13/afero v1.8.2 h1:xehSyVa0YnHWsJ49JFljMpg1HX19V6NDZ1fkm1Xznbo=
 github.com/spf13/afero v1.8.2/go.mod h1:CtAatgMJh6bJEIs48Ay/FOnkljP3WeGUG0MC1RfAqwo=
 github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=
 github.com/spf13/cast v1.5.0/go.mod h1:SpXXQ5YoyJw6s3/6cMTQuxvgRl3PCJiyaX9p6b155UU=
-github.com/spf13/cobra v1.4.0 h1:y+wJpx64xcgO1V+RcnwW0LEHxTKRi2ZDPSBjWnrg88Q=
-github.com/spf13/cobra v1.4.0/go.mod h1:Wo4iy3BUC+X2Fybo0PDqwJIv3dNRiZLHQymsfxlB84g=
 github.com/spf13/cobra v1.5.0 h1:X+jTBEBqF0bHN+9cSMgmfuvv2VHJ9ezmFNf9Y/XstYU=
 github.com/spf13/cobra v1.5.0/go.mod h1:dWXEIy2H428czQCjInthrTRUg7yKbok+2Qi/yBIJoUM=
 github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
@@ -391,8 +388,6 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
-github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.3.0 h1:mjC+YW8QpAdXibNi+vNWgzmgBH4+5l5dCXv8cNysBLI=
@@ -515,7 +510,6 @@ golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su
 golang.org/x/net v0.0.0-20220325170049-de3da57026de/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220412020605-290c469a71a5/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
-golang.org/x/net v0.0.0-20220520000938-2e3eb7b945c2 h1:NWy5+hlRbC7HK+PmcXVUmW1IMyFce7to56IUvhUFm7Y=
 golang.org/x/net v0.0.0-20220520000938-2e3eb7b945c2/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220708220712-1185a9018129 h1:vucSRfWwTsoXro7P+3Cjlr6flUMtzCwzlvkxEQtHHB0=
 golang.org/x/net v0.0.0-20220708220712-1185a9018129/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=


### PR DESCRIPTION
An earlier merged PR updated `hasScope` to match documentation in the `ginjwt` package so that it would validate all scopes in a roles claim, not any scope. However, it turns out downstream dependencies relied on existing behavior, so 

This PR adds an auth config item, `RoleValidationStrategy`, to switch between validating any and all scopes in `VerifyScopes`. Default behavior is `any` (i.e., any scope is valid).