### PR TITLE
Add toolbox-maintenance team as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @metal-toolbox/hollow-core
+* @metal-toolbox/toolbox-maintenance


### PR DESCRIPTION
This helps have more targetted reviewers

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
