### PR TITLE
Fix chainguard enforce configuration

### DIFF
--- a/.chainguard/source.yaml
+++ b/.chainguard/source.yaml
@@ -4,7 +4,7 @@ spec:
     # Accept all keyless signatures validated from the public sigstore instance.
     # This is open source software after all. All we want to know is that the
     # person that did the commit has control over their email address.
-    - keyless:
+    - keyless: {}
     # Add this if you also want to allow commits signed by GitHub.
     - key:
         kms: https://github.com/web-flow.gpg


### PR DESCRIPTION
The `keyless` configuration can't be empty, it needs to be set to an
empty dict in order to take the defaults and use sigstore's public
infrastructure.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
