### PR TITLE
Add ability to provide JWKS directly instead of through URI

### DIFF
--- a/ginauth/multitokenmiddleware_test.go
+++ b/ginauth/multitokenmiddleware_test.go
@@ -190,8 +190,8 @@ func TestMultitokenMiddlewareValidatesTokens(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.testName, func(t *testing.T) {
-			jwksURI1 := ginjwt.TestHelperJWKSProvider(ginjwt.TestPrivRSAKey1ID, ginjwt.TestPrivRSAKey2ID)
-			jwksURI2 := ginjwt.TestHelperJWKSProvider(ginjwt.TestPrivRSAKey3ID, ginjwt.TestPrivRSAKey4ID)
+			jwksURI1 := ginjwt.TestHelperJWKSURIProvider(ginjwt.TestPrivRSAKey1ID, ginjwt.TestPrivRSAKey2ID)
+			jwksURI2 := ginjwt.TestHelperJWKSURIProvider(ginjwt.TestPrivRSAKey3ID, ginjwt.TestPrivRSAKey4ID)
 
 			cfg1 := ginjwt.AuthConfig{Enabled: true, Audience: tt.middlewareAud, Issuer: tt.middlewareIss, JWKSURI: jwksURI1}
 			cfg2 := ginjwt.AuthConfig{Enabled: true, Audience: tt.middlewareAud, Issuer: tt.middlewareIss, JWKSURI: jwksURI2}
@@ -258,7 +258,7 @@ func TestMultitokenInvalidAuthHeader(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.testName, func(t *testing.T) {
-			jwksURI := ginjwt.TestHelperJWKSProvider(ginjwt.TestPrivRSAKey1ID, ginjwt.TestPrivRSAKey2ID)
+			jwksURI := ginjwt.TestHelperJWKSURIProvider(ginjwt.TestPrivRSAKey1ID, ginjwt.TestPrivRSAKey2ID)
 			cfg := ginjwt.AuthConfig{Enabled: true, Audience: "aud", Issuer: "iss", JWKSURI: jwksURI}
 			authMW, err := ginjwt.NewMultiTokenMiddlewareFromConfigs(cfg)
 			require.NoError(t, err)

--- a/ginjwt/errors.go
+++ b/ginjwt/errors.go
@@ -22,4 +22,7 @@ var (
 
 	// ErrMissingJWKURIFlag is an error returned when the JWK URI isn't provided via a command line flag.
 	ErrMissingJWKURIFlag = errors.New("JWK URI wasn't provided")
+
+	// ErrJWKSConfigConflict is an error when both JWKSURI and JWKS are set
+	ErrJWKSConfigConflict = errors.New("JWKS and JWKSURI can't both be set at the same time")
 )

--- a/ginjwt/jwt.go
+++ b/ginjwt/jwt.go
@@ -249,6 +249,11 @@ func (m *Middleware) VerifyScopes(c *gin.Context, scopes []string) error {
 func (m *Middleware) refreshJWKS() error {
 	var ctx context.Context
 
+	// When using JWKS directly, refresh should be a no-op
+	if len(m.config.JWKS.Keys) > 0 {
+		return nil
+	}
+
 	if m.config.JWKSRemoteTimeout != 0 {
 		var cancel context.CancelFunc
 
@@ -281,11 +286,6 @@ func (m *Middleware) refreshJWKS() error {
 func (m *Middleware) getJWKS(kid string) *jose.JSONWebKey {
 	keys := m.cachedJWKS.Key(kid)
 	if len(keys) == 0 {
-		// don't fetch JWKS from URI if we don't have one
-		if m.config.JWKSURI == "" {
-			return nil
-		}
-
 		// couldn't find the signing key in our cache, refresh cache and search again
 		if err := m.refreshJWKS(); err != nil {
 			return nil

--- a/ginjwt/jwt.go
+++ b/ginjwt/jwt.go
@@ -73,8 +73,12 @@ func NewAuthMiddleware(cfg AuthConfig) (*Middleware, error) {
 		return mw, nil
 	}
 
-	if cfg.JWKSURI != "" && len(cfg.JWKS.Keys) > 0 {
-		return nil, ErrJWKSConfigConflict
+	uriProvided := (cfg.JWKSURI != "")
+	jwksProvided := len(cfg.JWKS.Keys) > 0
+
+	// Either they were both provided, or neither was provided
+	if uriProvided == jwksProvided {
+		return nil, fmt.Errorf("%w: either JWKSURI or JWKS must be provided", ErrInvalidAuthConfig)
 	}
 
 	// Only refresh JWKSURI if static one isn't provided

--- a/ginjwt/jwt.go
+++ b/ginjwt/jwt.go
@@ -281,6 +281,11 @@ func (m *Middleware) refreshJWKS() error {
 func (m *Middleware) getJWKS(kid string) *jose.JSONWebKey {
 	keys := m.cachedJWKS.Key(kid)
 	if len(keys) == 0 {
+		// don't fetch JWKS from URI if we don't have one
+		if m.config.JWKSURI == "" {
+			return nil
+		}
+
 		// couldn't find the signing key in our cache, refresh cache and search again
 		if err := m.refreshJWKS(); err != nil {
 			return nil

--- a/ginjwt/jwt_test.go
+++ b/ginjwt/jwt_test.go
@@ -28,6 +28,7 @@ func TestMiddlewareValidatesTokensWithScopes(t *testing.T) {
 		middlewareScopes []string
 		signingKey       *rsa.PrivateKey
 		signingKeyID     string
+		jwksFromURI      bool
 		claims           jwt.Claims
 		claimScopes      []string
 		responseCode     int
@@ -40,6 +41,7 @@ func TestMiddlewareValidatesTokensWithScopes(t *testing.T) {
 			[]string{"testScope"},
 			ginjwt.TestPrivRSAKey1,
 			"randomUnknownID",
+			true,
 			jwt.Claims{
 				Subject:   "test-user",
 				Issuer:    "ginjwt.test.issuer",
@@ -57,6 +59,7 @@ func TestMiddlewareValidatesTokensWithScopes(t *testing.T) {
 			[]string{"testScope"},
 			ginjwt.TestPrivRSAKey1,
 			ginjwt.TestPrivRSAKey2ID,
+			true,
 			jwt.Claims{
 				Subject:   "test-user",
 				Issuer:    "ginjwt.test.issuer",
@@ -74,6 +77,7 @@ func TestMiddlewareValidatesTokensWithScopes(t *testing.T) {
 			[]string{"testScope"},
 			ginjwt.TestPrivRSAKey1,
 			ginjwt.TestPrivRSAKey1ID,
+			true,
 			jwt.Claims{
 				Subject:   "test-user",
 				Issuer:    "ginjwt.test.issuer",
@@ -91,6 +95,7 @@ func TestMiddlewareValidatesTokensWithScopes(t *testing.T) {
 			[]string{"testScope"},
 			ginjwt.TestPrivRSAKey1,
 			ginjwt.TestPrivRSAKey1ID,
+			true,
 			jwt.Claims{
 				Subject:   "test-user",
 				Issuer:    "ginjwt.test.issuer",
@@ -108,6 +113,7 @@ func TestMiddlewareValidatesTokensWithScopes(t *testing.T) {
 			[]string{"adminscope"},
 			ginjwt.TestPrivRSAKey1,
 			ginjwt.TestPrivRSAKey1ID,
+			true,
 			jwt.Claims{
 				Subject:   "test-user",
 				Issuer:    "ginjwt.test.issuer",
@@ -125,6 +131,7 @@ func TestMiddlewareValidatesTokensWithScopes(t *testing.T) {
 			[]string{"testScope"},
 			ginjwt.TestPrivRSAKey1,
 			ginjwt.TestPrivRSAKey1ID,
+			true,
 			jwt.Claims{
 				Subject:   "test-user",
 				Issuer:    "ginjwt.test.issuer",
@@ -143,6 +150,7 @@ func TestMiddlewareValidatesTokensWithScopes(t *testing.T) {
 			[]string{"testScope"},
 			ginjwt.TestPrivRSAKey1,
 			ginjwt.TestPrivRSAKey1ID,
+			true,
 			jwt.Claims{
 				Subject:   "test-user",
 				Issuer:    "ginjwt.test.issuer",
@@ -160,6 +168,7 @@ func TestMiddlewareValidatesTokensWithScopes(t *testing.T) {
 			[]string{"testScope"},
 			ginjwt.TestPrivRSAKey1,
 			ginjwt.TestPrivRSAKey1ID,
+			true,
 			jwt.Claims{
 				Subject:   "test-user",
 				Issuer:    "ginjwt.test.issuer",
@@ -170,13 +179,55 @@ func TestMiddlewareValidatesTokensWithScopes(t *testing.T) {
 			http.StatusOK,
 			"ok",
 		},
+		{
+			"valid with directly loaded JWKS",
+			"ginjwt.test",
+			"ginjwt.test.issuer",
+			[]string{"testScope"},
+			ginjwt.TestPrivRSAKey1,
+			ginjwt.TestPrivRSAKey1ID,
+			false,
+			jwt.Claims{
+				Subject:   "test-user",
+				Issuer:    "ginjwt.test.issuer",
+				NotBefore: jwt.NewNumericDate(time.Now().Add(-2 * time.Hour)),
+				Audience:  jwt.Audience{"ginjwt.test", "another.test.service"},
+			},
+			[]string{"testScope", "anotherScope", "more-scopes"},
+			http.StatusOK,
+			"ok",
+		},
+		{
+			"valid with directly loaded JWKS",
+			"ginjwt.test",
+			"ginjwt.test.issuer",
+			[]string{"testScope"},
+			ginjwt.TestPrivRSAKey1,
+			"invalid-key-id",
+			false,
+			jwt.Claims{
+				Subject:   "test-user",
+				Issuer:    "ginjwt.test.issuer",
+				NotBefore: jwt.NewNumericDate(time.Now().Add(-2 * time.Hour)),
+				Audience:  jwt.Audience{"ginjwt.test", "another.test.service"},
+			},
+			[]string{"testScope", "anotherScope", "more-scopes"},
+			http.StatusUnauthorized,
+			"invalid token signing key",
+		},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.testName, func(t *testing.T) {
-			jwksURI := ginjwt.TestHelperJWKSURIProvider(ginjwt.TestPrivRSAKey1ID, ginjwt.TestPrivRSAKey2ID)
+			var jwksURI string
+			var jwks jose.JSONWebKeySet
+			if tt.jwksFromURI {
+				jwksURI = ginjwt.TestHelperJWKSURIProvider(ginjwt.TestPrivRSAKey1ID, ginjwt.TestPrivRSAKey2ID)
+			} else {
+				jwks = ginjwt.TestHelperJWKSProvider(ginjwt.TestPrivRSAKey1ID, ginjwt.TestPrivRSAKey2ID)
+			}
 
-			cfg := ginjwt.AuthConfig{Enabled: true, Audience: tt.middlewareAud, Issuer: tt.middlewareIss, JWKSURI: jwksURI}
+			cfg := ginjwt.AuthConfig{Enabled: true, Audience: tt.middlewareAud, Issuer: tt.middlewareIss, JWKSURI: jwksURI, JWKS: jwks}
 			authMW, err := ginjwt.NewAuthMiddleware(cfg)
 			require.NoError(t, err)
 
@@ -669,7 +720,19 @@ func TestAuthMiddlewareConfig(t *testing.T) {
 				RoleValidationStrategy: "all",
 			},
 			checkFn: func(t *testing.T, mw ginauth.GenericAuthMiddleware, err error) {
-				assert.ErrorIs(t, err, ginjwt.ErrJWKSConfigConflict)
+				assert.ErrorIs(t, err, ginjwt.ErrInvalidAuthConfig)
+			},
+		},
+		{
+			name: "MissingJWKSConfig",
+			input: ginjwt.AuthConfig{
+				Enabled:                true,
+				Audience:               "example-aud",
+				Issuer:                 "example-iss",
+				RoleValidationStrategy: "all",
+			},
+			checkFn: func(t *testing.T, mw ginauth.GenericAuthMiddleware, err error) {
+				assert.ErrorIs(t, err, ginjwt.ErrInvalidAuthConfig)
 			},
 		},
 	}

--- a/ginjwt/jwt_test.go
+++ b/ginjwt/jwt_test.go
@@ -180,7 +180,7 @@ func TestMiddlewareValidatesTokensWithScopes(t *testing.T) {
 			"ok",
 		},
 		{
-			"valid with directly loaded JWKS",
+			"invalid key with directly loaded JWKS",
 			"ginjwt.test",
 			"ginjwt.test.issuer",
 			[]string{"testScope"},

--- a/ginjwt/testtools.go
+++ b/ginjwt/testtools.go
@@ -55,11 +55,8 @@ func TestHelperMustMakeSigner(alg jose.SignatureAlgorithm, kid string, k interfa
 	return sig
 }
 
-// TestHelperJWKSProvider returns a url for a webserver that will return JSONWebKeySets
-func TestHelperJWKSProvider(keyIDs ...string) string {
-	gin.SetMode(gin.TestMode)
-	r := gin.New()
-
+// TestHelperJWKSProvider returns a JWKS
+func TestHelperJWKSProvider(keyIDs ...string) jose.JSONWebKeySet {
 	jwks := make([]jose.JSONWebKey, len(keyIDs))
 
 	for idx, keyID := range keyIDs {
@@ -76,10 +73,20 @@ func TestHelperJWKSProvider(keyIDs ...string) string {
 		}
 	}
 
+	return jose.JSONWebKeySet{
+		Keys: jwks,
+	}
+}
+
+// TestHelperJWKSURIProvider returns a url for a webserver that will return JSONWebKeySets
+func TestHelperJWKSURIProvider(keyIDs ...string) string {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+
+	keySet := TestHelperJWKSProvider(keyIDs...)
+
 	r.GET("/.well-known/jwks.json", func(c *gin.Context) {
-		c.JSON(http.StatusOK, jose.JSONWebKeySet{
-			Keys: jwks,
-		})
+		c.JSON(http.StatusOK, keySet)
 	})
 
 	listener, err := net.Listen("tcp", ":0")


### PR DESCRIPTION
This adds the JWKS field to the AuthConfig which allows you to pass a `jose.JSONWebKeySet` directly to the config instead of attempting to fetch from a URI.

Signed-off-by: Adam Mohammed <admohammed@equinix.com>