### PR TITLE
Undo breaking change to test helpers

### DIFF
--- a/ginauth/multitokenmiddleware_test.go
+++ b/ginauth/multitokenmiddleware_test.go
@@ -190,8 +190,8 @@ func TestMultitokenMiddlewareValidatesTokens(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.testName, func(t *testing.T) {
-			jwksURI1 := ginjwt.TestHelperJWKSURIProvider(ginjwt.TestPrivRSAKey1ID, ginjwt.TestPrivRSAKey2ID)
-			jwksURI2 := ginjwt.TestHelperJWKSURIProvider(ginjwt.TestPrivRSAKey3ID, ginjwt.TestPrivRSAKey4ID)
+			jwksURI1 := ginjwt.TestHelperJWKSProvider(ginjwt.TestPrivRSAKey1ID, ginjwt.TestPrivRSAKey2ID)
+			jwksURI2 := ginjwt.TestHelperJWKSProvider(ginjwt.TestPrivRSAKey3ID, ginjwt.TestPrivRSAKey4ID)
 
 			cfg1 := ginjwt.AuthConfig{Enabled: true, Audience: tt.middlewareAud, Issuer: tt.middlewareIss, JWKSURI: jwksURI1}
 			cfg2 := ginjwt.AuthConfig{Enabled: true, Audience: tt.middlewareAud, Issuer: tt.middlewareIss, JWKSURI: jwksURI2}
@@ -258,7 +258,7 @@ func TestMultitokenInvalidAuthHeader(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.testName, func(t *testing.T) {
-			jwksURI := ginjwt.TestHelperJWKSURIProvider(ginjwt.TestPrivRSAKey1ID, ginjwt.TestPrivRSAKey2ID)
+			jwksURI := ginjwt.TestHelperJWKSProvider(ginjwt.TestPrivRSAKey1ID, ginjwt.TestPrivRSAKey2ID)
 			cfg := ginjwt.AuthConfig{Enabled: true, Audience: "aud", Issuer: "iss", JWKSURI: jwksURI}
 			authMW, err := ginjwt.NewMultiTokenMiddlewareFromConfigs(cfg)
 			require.NoError(t, err)

--- a/ginjwt/jwt_test.go
+++ b/ginjwt/jwt_test.go
@@ -222,9 +222,9 @@ func TestMiddlewareValidatesTokensWithScopes(t *testing.T) {
 			var jwksURI string
 			var jwks jose.JSONWebKeySet
 			if tt.jwksFromURI {
-				jwksURI = ginjwt.TestHelperJWKSURIProvider(ginjwt.TestPrivRSAKey1ID, ginjwt.TestPrivRSAKey2ID)
+				jwksURI = ginjwt.TestHelperJWKSProvider(ginjwt.TestPrivRSAKey1ID, ginjwt.TestPrivRSAKey2ID)
 			} else {
-				jwks = ginjwt.TestHelperJWKSProvider(ginjwt.TestPrivRSAKey1ID, ginjwt.TestPrivRSAKey2ID)
+				jwks = ginjwt.TestHelperJoseJWKSProvider(ginjwt.TestPrivRSAKey1ID, ginjwt.TestPrivRSAKey2ID)
 			}
 
 			cfg := ginjwt.AuthConfig{Enabled: true, Audience: tt.middlewareAud, Issuer: tt.middlewareIss, JWKSURI: jwksURI, JWKS: jwks}
@@ -389,7 +389,7 @@ func TestMiddlewareAuthRequired(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.testName, func(t *testing.T) {
-			jwksURI := ginjwt.TestHelperJWKSURIProvider(ginjwt.TestPrivRSAKey1ID, ginjwt.TestPrivRSAKey2ID)
+			jwksURI := ginjwt.TestHelperJWKSProvider(ginjwt.TestPrivRSAKey1ID, ginjwt.TestPrivRSAKey2ID)
 
 			cfg := ginjwt.AuthConfig{Enabled: true, Audience: tt.middlewareAud, Issuer: tt.middlewareIss, JWKSURI: jwksURI}
 			authMW, err := ginjwt.NewAuthMiddleware(cfg)
@@ -451,7 +451,7 @@ func TestInvalidAuthHeader(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.testName, func(t *testing.T) {
-			jwksURI := ginjwt.TestHelperJWKSURIProvider(ginjwt.TestPrivRSAKey1ID, ginjwt.TestPrivRSAKey2ID)
+			jwksURI := ginjwt.TestHelperJWKSProvider(ginjwt.TestPrivRSAKey1ID, ginjwt.TestPrivRSAKey2ID)
 			cfg := ginjwt.AuthConfig{Enabled: true, Audience: "aud", Issuer: "iss", JWKSURI: jwksURI}
 			authMW, err := ginjwt.NewAuthMiddleware(cfg)
 			require.NoError(t, err)
@@ -475,7 +475,7 @@ func TestInvalidAuthHeader(t *testing.T) {
 }
 
 func TestInvalidJWKURIWithWrongPath(t *testing.T) {
-	uri := ginjwt.TestHelperJWKSURIProvider(ginjwt.TestPrivRSAKey1ID, ginjwt.TestPrivRSAKey2ID)
+	uri := ginjwt.TestHelperJWKSProvider(ginjwt.TestPrivRSAKey1ID, ginjwt.TestPrivRSAKey2ID)
 	uri += "/some-extra-path"
 	cfg := ginjwt.AuthConfig{Enabled: true, Audience: "aud", Issuer: "iss", JWKSURI: uri}
 	_, err := ginjwt.NewAuthMiddleware(cfg)
@@ -639,7 +639,7 @@ func TestVerifyTokenWithScopes(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.testName, func(t *testing.T) {
-			jwksURI := ginjwt.TestHelperJWKSURIProvider(ginjwt.TestPrivRSAKey1ID, ginjwt.TestPrivRSAKey2ID)
+			jwksURI := ginjwt.TestHelperJWKSProvider(ginjwt.TestPrivRSAKey1ID, ginjwt.TestPrivRSAKey2ID)
 			config := ginjwt.AuthConfig{
 				Enabled:                true,
 				Audience:               tt.middlewareAud,
@@ -673,8 +673,8 @@ func TestVerifyTokenWithScopes(t *testing.T) {
 }
 
 func TestAuthMiddlewareConfig(t *testing.T) {
-	jwks := ginjwt.TestHelperJWKSProvider(ginjwt.TestPrivRSAKey1ID, ginjwt.TestPrivRSAKey2ID)
-	jwksURI := ginjwt.TestHelperJWKSURIProvider(ginjwt.TestPrivRSAKey1ID, ginjwt.TestPrivRSAKey2ID)
+	jwks := ginjwt.TestHelperJoseJWKSProvider(ginjwt.TestPrivRSAKey1ID, ginjwt.TestPrivRSAKey2ID)
+	jwksURI := ginjwt.TestHelperJWKSProvider(ginjwt.TestPrivRSAKey1ID, ginjwt.TestPrivRSAKey2ID)
 
 	testCases := []struct {
 		name    string

--- a/ginjwt/testtools.go
+++ b/ginjwt/testtools.go
@@ -55,8 +55,8 @@ func TestHelperMustMakeSigner(alg jose.SignatureAlgorithm, kid string, k interfa
 	return sig
 }
 
-// TestHelperJWKSProvider returns a JWKS
-func TestHelperJWKSProvider(keyIDs ...string) jose.JSONWebKeySet {
+// TestHelperJoseJWKSProvider returns a JWKS
+func TestHelperJoseJWKSProvider(keyIDs ...string) jose.JSONWebKeySet {
 	jwks := make([]jose.JSONWebKey, len(keyIDs))
 
 	for idx, keyID := range keyIDs {
@@ -78,12 +78,12 @@ func TestHelperJWKSProvider(keyIDs ...string) jose.JSONWebKeySet {
 	}
 }
 
-// TestHelperJWKSURIProvider returns a url for a webserver that will return JSONWebKeySets
-func TestHelperJWKSURIProvider(keyIDs ...string) string {
+// TestHelperJWKSProvider returns a url for a webserver that will return JSONWebKeySets
+func TestHelperJWKSProvider(keyIDs ...string) string {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 
-	keySet := TestHelperJWKSProvider(keyIDs...)
+	keySet := TestHelperJoseJWKSProvider(keyIDs...)
 
 	r.GET("/.well-known/jwks.json", func(c *gin.Context) {
 		c.JSON(http.StatusOK, keySet)


### PR DESCRIPTION
In #79, `TestHelperJWKSPRovider` was renamed to
`TestHelperJWKSURIProvider` since it returns a URI and not a JWKS and another function was added with that name that returned a JWKS. Since testtools is exported, there are consumers that break due to this change.