### PR TITLE
add the PublisherSubjectPrefix

### DIFF
--- a/events/nats.go
+++ b/events/nats.go
@@ -224,8 +224,9 @@ func (n *NatsJetstream) addConsumer() error {
 }
 
 // Publish publishes an event onto the NATS Jetstream. The caller is responsible for message
-// addressing and data serialization.
-func (n *NatsJetstream) Publish(_ context.Context, subject string, data []byte) error {
+// addressing and data serialization. NOTE: The subject passed here will be prepended with any
+// configured PublisherSubjectPrefix.
+func (n *NatsJetstream) Publish(_ context.Context, subjectSuffix string, data []byte) error {
 	if n.jsctx == nil {
 		return errors.Wrap(ErrNatsJetstreamAddConsumer, "Jetstream context is not setup")
 	}
@@ -238,7 +239,7 @@ func (n *NatsJetstream) Publish(_ context.Context, subject string, data []byte) 
 	fullSubject := strings.Join(
 		[]string{
 			n.parameters.PublisherSubjectPrefix,
-			subject,
+			subjectSuffix,
 		}, ".")
 
 	_, err := n.jsctx.Publish(fullSubject, data, options...)

--- a/events/nats.go
+++ b/events/nats.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"log"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -234,7 +235,13 @@ func (n *NatsJetstream) Publish(_ context.Context, subject string, data []byte) 
 		nats.RetryAttempts(-1),
 	}
 
-	_, err := n.jsctx.Publish(subject, data, options...)
+	fullSubject := strings.Join(
+		[]string{
+			n.parameters.PublisherSubjectPrefix,
+			subject,
+		}, ".")
+
+	_, err := n.jsctx.Publish(fullSubject, data, options...)
 	return err
 }
 

--- a/events/nats_test.go
+++ b/events/nats_test.go
@@ -56,7 +56,7 @@ func TestPublishAndSubscribe(t *testing.T) {
 		Stream: &NatsStreamOptions{
 			Name: "test_stream",
 			Subjects: []string{
-				"test",
+				"pre.test",
 			},
 			Retention: "workQueue",
 		},
@@ -64,10 +64,11 @@ func TestPublishAndSubscribe(t *testing.T) {
 			Name: "test_consumer",
 			Pull: true,
 			SubscribeSubjects: []string{
-				"test",
+				"pre.test",
 			},
-			FilterSubject: "test",
+			FilterSubject: "pre.test",
 		},
+		PublisherSubjectPrefix: "pre",
 	}
 	require.NoError(t, njs.addStream())
 	require.NoError(t, njs.addConsumer())


### PR DESCRIPTION
The NatsJetstream object can be configured with a subject-prefix to disambiguate subjects between participants on a NATS server. Without this change, the prefix will be ignored on a publish, resulting in rejected (or worse, misdirected) messages.