### PR TITLE
add replicas for streams

### DIFF
--- a/events/nats.go
+++ b/events/nats.go
@@ -45,6 +45,13 @@ type NatsJetstream struct {
 	subscriberCh  MsgCh
 }
 
+func (n *NatsJetstream) streamReplicas() int {
+	if n.parameters.Stream.Replicas == 0 {
+		return 1
+	}
+	return n.parameters.Stream.Replicas
+}
+
 // Add some conversions for functions/APIs that expect NATS primitive types. This allows consumers of
 // NatsJetsream to convert easily to the types they need, without exporting the members or coercing
 // and direct clients/holders of NatsJetstream to do this conversion.
@@ -178,6 +185,7 @@ func (n *NatsJetstream) addStream() error {
 			Name:      n.parameters.Stream.Name,
 			Subjects:  n.parameters.Stream.Subjects,
 			Retention: retention,
+			Replicas:  n.streamReplicas(),
 		},
 	)
 
@@ -198,7 +206,7 @@ func (n *NatsJetstream) addConsumer() error {
 	}
 
 	// lookup consumers in stream before attempting to add consumer
-	for name := range n.jsctx.ConsumerNames(n.parameters.Stream.Name) {
+	for name := range n.jsctx.ConsumerNames(n.parameters.Consumer.Name) {
 		if name == n.parameters.Consumer.Name {
 			return nil
 		}

--- a/events/nats_config.go
+++ b/events/nats_config.go
@@ -119,6 +119,9 @@ type NatsStreamOptions struct {
 	//
 	// https://docs.nats.io/using-nats/developer/develop_jetstream/model_deep_dive#stream-limits-retention-and-policy
 	Retention string `mapstructure:"retention"`
+
+	// Replicas specifies the number of replicas we use for this stream
+	Replicas int `mapstructure:"replicas"`
 }
 
 func (o *NatsOptions) validate() error {
@@ -166,6 +169,10 @@ func (o *NatsOptions) validatePrereqs() error {
 }
 
 func (s *NatsStreamOptions) validate() error {
+	if s == nil {
+		return errors.Wrap(ErrNatsConfig, "stream configuration is missing")
+	}
+
 	if s.Retention == "" {
 		s.Retention = "limits"
 	}
@@ -186,6 +193,10 @@ func (s *NatsStreamOptions) validate() error {
 }
 
 func (c *NatsConsumerOptions) validate() error {
+	if c == nil {
+		return errors.Wrap(ErrNatsConfig, "consumer configuration is missing")
+	}
+
 	if c.Name == "" {
 		return errors.Wrap(ErrNatsConfig, "consumer parameters require a Name")
 	}

--- a/events/nats_config_test.go
+++ b/events/nats_config_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNatsOptions_ValidatePrereqs(t *testing.T) {
@@ -77,6 +78,24 @@ func TestNatsOptions_ValidatePrereqs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNilParams(t *testing.T) {
+	t.Parallel()
+	t.Run("nil stream parameters", func(t *testing.T) {
+		t.Parallel()
+		o := &NatsOptions{}
+		var err error
+		require.NotPanics(t, func() { err = o.Stream.validate() }, "stream param panic")
+		require.ErrorIs(t, err, ErrNatsConfig, "stream validate error")
+	})
+	t.Run("nil consumer parameters", func(t *testing.T) {
+		t.Parallel()
+		o := &NatsOptions{}
+		var err error
+		require.NotPanics(t, func() { err = o.Consumer.validate() }, "consumer param panic")
+		require.ErrorIs(t, err, ErrNatsConfig, "consumer validate error")
+	})
 }
 
 func TestNatsStreamOptions_Validate(t *testing.T) {


### PR DESCRIPTION
This adds a provision for NATS streams to have more than a single replica for availability purposes.