### PR TITLE
preserve NATS error type

### DIFF
--- a/events/nats.go
+++ b/events/nats.go
@@ -331,7 +331,7 @@ func (n *NatsJetstream) PullMsg(_ context.Context, batch int) ([]Message, error)
 
 		subMsgs, err := subscription.Fetch(batch)
 		if err != nil {
-			return nil, errors.Wrap(ErrNatsMsgPull, err.Error())
+			return nil, errors.Wrap(err, ErrNatsMsgPull.Error())
 		}
 		msgs = append(msgs, msgIfFromNats(subMsgs...)...)
 	}

--- a/events/nats_test.go
+++ b/events/nats_test.go
@@ -88,6 +88,10 @@ func TestPublishAndSubscribe(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(msgs))
 	require.Equal(t, payload, msgs[0].Data())
+
+	msgs, err = njs.PullMsg(context.TODO(), 1)
+	require.Error(t, err)
+	require.ErrorIs(t, err, nats.ErrTimeout)
 }
 
 func TestInjectOtelTraceContext(t *testing.T) {


### PR DESCRIPTION
Clients of events (in this case specifically Flasher) rely on the error type returned from this library for error handling. This change wraps the NATS error with a library message instead of using the NATS error to enrich a stock library error. This facilitates a test of `errors.Is(err, nats.Timeout)` for the case where we want to ignore an error.

An alternative could be to detect the NATS error and rewrite it conditionally into native events errors, but that is additional work for no additional operation benefit.