### PR TITLE
Nats kv config

### DIFF
--- a/events/nats.go
+++ b/events/nats.go
@@ -223,7 +223,11 @@ func (n *NatsJetstream) addConsumer() error {
 	for name := range n.jsctx.ConsumerNames(n.parameters.Stream.Name) {
 		consumerInfo, err := n.jsctx.ConsumerInfo(n.parameters.Stream.Name, n.parameters.Consumer.Name)
 		if err != nil {
-			return errors.Wrap(err, ErrNatsJetstreamAddConsumer.Error())
+			if errors.Is(err, nats.ErrConsumerNotFound) {
+				break
+			}
+
+			return errors.Wrap(err, ErrNatsJetstreamAddConsumer.Error()+" consumer.Name="+n.parameters.Consumer.Name)
 		}
 
 		if name == n.parameters.Consumer.Name && !n.consumerConfigIsEqual(consumerInfo) {

--- a/events/nats_config.go
+++ b/events/nats_config.go
@@ -66,14 +66,6 @@ type NatsOptions struct {
 
 	// Setting Stream parameters will cause a NATS stream to be added.
 	Stream *NatsStreamOptions `mapstructure:"stream"`
-
-	// Nats KV parameters
-	KV *NatsKVOptions `mapstructure:"kv"`
-}
-
-// NatsKVOptions are the NATS k/v parameters
-type NatsKVOptions struct {
-	ReplicaCount int `mapstructure:"replica_count"`
 }
 
 // NatsConsumerOptions is the parameters for the NATS consumer configuration.

--- a/events/nats_config.go
+++ b/events/nats_config.go
@@ -66,6 +66,14 @@ type NatsOptions struct {
 
 	// Setting Stream parameters will cause a NATS stream to be added.
 	Stream *NatsStreamOptions `mapstructure:"stream"`
+
+	// Nats KV parameters
+	KV *NatsKVOptions `mapstructure:"kv"`
+}
+
+// NatsKVOptions are the NATS k/v parameters
+type NatsKVOptions struct {
+	ReplicaCount int `mapstructure:"replica_count"`
 }
 
 // NatsConsumerOptions is the parameters for the NATS consumer configuration.


### PR DESCRIPTION
- Fixes a bug - create consumer when it doesn't exist, instead of returning an error
- Declare NATS kv config parameter