### PR TITLE
ginjwt/Validate config

### DIFF
--- a/events/nats_config_test.go
+++ b/events/nats_config_test.go
@@ -66,6 +66,7 @@ func TestNatsOptions_ValidatePrereqs(t *testing.T) {
 				CredsFile:      tt.fields.CredsFile,
 				ConnectTimeout: tt.fields.ConnectTimeout,
 			}
+
 			err := o.validatePrereqs()
 			if tt.errorContains != "" {
 				assert.True(t, errors.Is(err, ErrNatsConfig))
@@ -180,6 +181,7 @@ func TestNatsConsumerOptions_Validate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &NatsConsumerOptions{Name: tt.fields.Name}
+
 			err := c.validate()
 			if tt.errorContains != "" {
 				assert.True(t, errors.Is(err, ErrNatsConfig))

--- a/ginjwt/jwt.go
+++ b/ginjwt/jwt.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"gopkg.in/square/go-jose.v2"
 	"gopkg.in/square/go-jose.v2/jwt"
@@ -71,6 +72,14 @@ func NewAuthMiddleware(cfg AuthConfig) (*Middleware, error) {
 
 	if !cfg.Enabled {
 		return mw, nil
+	}
+
+	if cfg.Audience == "" {
+		return nil, errors.Wrap(ErrInvalidAudience, "empty value")
+	}
+
+	if cfg.Issuer == "" {
+		return nil, errors.Wrap(ErrInvalidIssuer, "empty value")
 	}
 
 	uriProvided := (cfg.JWKSURI != "")

--- a/ginjwt/jwt_test.go
+++ b/ginjwt/jwt_test.go
@@ -735,6 +735,30 @@ func TestAuthMiddlewareConfig(t *testing.T) {
 				assert.ErrorIs(t, err, ginjwt.ErrInvalidAuthConfig)
 			},
 		},
+		{
+			name: "MissingAudience",
+			input: ginjwt.AuthConfig{
+				Enabled:                true,
+				Audience:               "",
+				Issuer:                 "example-iss",
+				RoleValidationStrategy: "all",
+			},
+			checkFn: func(t *testing.T, mw ginauth.GenericAuthMiddleware, err error) {
+				assert.ErrorIs(t, err, ginjwt.ErrInvalidAudience)
+			},
+		},
+		{
+			name: "MissingIssuer",
+			input: ginjwt.AuthConfig{
+				Enabled:                true,
+				Audience:               "example-aud",
+				Issuer:                 "",
+				RoleValidationStrategy: "all",
+			},
+			checkFn: func(t *testing.T, mw ginauth.GenericAuthMiddleware, err error) {
+				assert.ErrorIs(t, err, ginjwt.ErrInvalidIssuer)
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/ginjwt/jwt_test.go
+++ b/ginjwt/jwt_test.go
@@ -220,7 +220,9 @@ func TestMiddlewareValidatesTokensWithScopes(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.testName, func(t *testing.T) {
 			var jwksURI string
+
 			var jwks jose.JSONWebKeySet
+
 			if tt.jwksFromURI {
 				jwksURI = ginjwt.TestHelperJWKSProvider(ginjwt.TestPrivRSAKey1ID, ginjwt.TestPrivRSAKey2ID)
 			} else {
@@ -719,7 +721,7 @@ func TestAuthMiddlewareConfig(t *testing.T) {
 				JWKS:                   jwks,
 				RoleValidationStrategy: "all",
 			},
-			checkFn: func(t *testing.T, mw ginauth.GenericAuthMiddleware, err error) {
+			checkFn: func(t *testing.T, _ ginauth.GenericAuthMiddleware, err error) {
 				assert.ErrorIs(t, err, ginjwt.ErrInvalidAuthConfig)
 			},
 		},
@@ -731,7 +733,7 @@ func TestAuthMiddlewareConfig(t *testing.T) {
 				Issuer:                 "example-iss",
 				RoleValidationStrategy: "all",
 			},
-			checkFn: func(t *testing.T, mw ginauth.GenericAuthMiddleware, err error) {
+			checkFn: func(t *testing.T, _ ginauth.GenericAuthMiddleware, err error) {
 				assert.ErrorIs(t, err, ginjwt.ErrInvalidAuthConfig)
 			},
 		},
@@ -743,7 +745,7 @@ func TestAuthMiddlewareConfig(t *testing.T) {
 				Issuer:                 "example-iss",
 				RoleValidationStrategy: "all",
 			},
-			checkFn: func(t *testing.T, mw ginauth.GenericAuthMiddleware, err error) {
+			checkFn: func(t *testing.T, _ ginauth.GenericAuthMiddleware, err error) {
 				assert.ErrorIs(t, err, ginjwt.ErrInvalidAudience)
 			},
 		},
@@ -755,7 +757,7 @@ func TestAuthMiddlewareConfig(t *testing.T) {
 				Issuer:                 "",
 				RoleValidationStrategy: "all",
 			},
-			checkFn: func(t *testing.T, mw ginauth.GenericAuthMiddleware, err error) {
+			checkFn: func(t *testing.T, _ ginauth.GenericAuthMiddleware, err error) {
 				assert.ErrorIs(t, err, ginjwt.ErrInvalidIssuer)
 			},
 		},

--- a/ginjwt/multitokenmiddleware.go
+++ b/ginjwt/multitokenmiddleware.go
@@ -1,9 +1,16 @@
 package ginjwt
 
-import "go.hollow.sh/toolbox/ginauth"
+import (
+	"github.com/pkg/errors"
+	"go.hollow.sh/toolbox/ginauth"
+)
 
 // NewMultiTokenMiddlewareFromConfigs builds a MultiTokenMiddleware object from multiple AuthConfigs.
 func NewMultiTokenMiddlewareFromConfigs(cfgs ...AuthConfig) (*ginauth.MultiTokenMiddleware, error) {
+	if len(cfgs) == 0 {
+		return nil, errors.Wrap(ErrInvalidAuthConfig, "configuration empty")
+	}
+
 	mtm := &ginauth.MultiTokenMiddleware{}
 
 	for _, cfg := range cfgs {

--- a/ginjwt/multitokenmiddleware.go
+++ b/ginjwt/multitokenmiddleware.go
@@ -2,6 +2,7 @@ package ginjwt
 
 import (
 	"github.com/pkg/errors"
+
 	"go.hollow.sh/toolbox/ginauth"
 )
 


### PR DESCRIPTION
- Validate multitoken configuration, when creating a new instance, instead of returning as is.
- Validate required Audience, Issuer fields.

This prevents callers from misconfiguring their services, by enforcing the configuration requirements.