### PR TITLE
Change module path

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,7 +51,7 @@ formatters:
       extra-rules: true
     goimports:
       local-prefixes:
-        - go.hollow.sh/toolbox
+        - github.com/metal-toolbox/hollow-toolbox
   exclusions:
     generated: lax
     paths:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Go Reference](https://pkg.go.dev/badge/go.hollow.sh/toolbox.svg)](https://pkg.go.dev/go.hollow.sh/toolbox)
+[![Go Reference](https://pkg.go.dev/badge/github.com/metal-toolbox/hollow-toolbox.svg)](https://pkg.go.dev/github.com/metal-toolbox/hollow-toolbox)
 
 # Hollow Toolbox
 

--- a/events/mock/events.go
+++ b/events/mock/events.go
@@ -9,7 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	events "go.hollow.sh/toolbox/events"
+	events "github.com/metal-toolbox/hollow-toolbox/events"
 )
 
 // MockStreamParameters is a mock of StreamParameters interface.

--- a/events/nats_test.go
+++ b/events/nats_test.go
@@ -14,7 +14,7 @@ import (
 	traceSDK "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 
-	natsTest "go.hollow.sh/toolbox/events/internal/test"
+	natsTest "github.com/metal-toolbox/hollow-toolbox/events/internal/test"
 )
 
 func TestJetstreamFromConn(t *testing.T) {

--- a/events/pkg/kv/kv.go
+++ b/events/pkg/kv/kv.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/nats-io/nats.go"
 
-	"go.hollow.sh/toolbox/events"
+	"github.com/metal-toolbox/hollow-toolbox/events"
 )
 
 // DefaultKVConfig returns a configuration with "mostly sane" defaults. Override

--- a/events/pkg/kv/kv_test.go
+++ b/events/pkg/kv/kv_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/nats-io/nats.go"
 
-	"go.hollow.sh/toolbox/events"
-	kvTest "go.hollow.sh/toolbox/events/internal/test"
+	"github.com/metal-toolbox/hollow-toolbox/events"
+	kvTest "github.com/metal-toolbox/hollow-toolbox/events/internal/test"
 
 	"github.com/stretchr/testify/require"
 )

--- a/events/registry/registry.go
+++ b/events/registry/registry.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/nats-io/nats.go"
 
-	"go.hollow.sh/toolbox/events"
-	"go.hollow.sh/toolbox/events/pkg/kv"
+	"github.com/metal-toolbox/hollow-toolbox/events"
+	"github.com/metal-toolbox/hollow-toolbox/events/pkg/kv"
 )
 
 var (

--- a/events/registry/registry_test.go
+++ b/events/registry/registry_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/require"
 
-	"go.hollow.sh/toolbox/events"
-	kvTest "go.hollow.sh/toolbox/events/internal/test"
+	"github.com/metal-toolbox/hollow-toolbox/events"
+	kvTest "github.com/metal-toolbox/hollow-toolbox/events/internal/test"
 )
 
 func TestAppLifecycle(t *testing.T) {

--- a/ginauth/multitokenmiddleware_test.go
+++ b/ginauth/multitokenmiddleware_test.go
@@ -16,8 +16,8 @@ import (
 	"gopkg.in/go-jose/go-jose.v2"
 	"gopkg.in/go-jose/go-jose.v2/jwt"
 
-	"go.hollow.sh/toolbox/ginauth"
-	"go.hollow.sh/toolbox/ginjwt"
+	"github.com/metal-toolbox/hollow-toolbox/ginauth"
+	"github.com/metal-toolbox/hollow-toolbox/ginjwt"
 )
 
 func TestMultitokenMiddlewareValidatesTokens(t *testing.T) {

--- a/ginauth/remote_test.go
+++ b/ginauth/remote_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 
-	"go.hollow.sh/toolbox/ginauth"
+	"github.com/metal-toolbox/hollow-toolbox/ginauth"
 )
 
 func getNewTestRemoteAuthServer(resp *ginauth.AuthResponseV1, forcedSleep time.Duration) string {

--- a/ginjwt/helpers_test.go
+++ b/ginjwt/helpers_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 
-	"go.hollow.sh/toolbox/ginjwt"
+	"github.com/metal-toolbox/hollow-toolbox/ginjwt"
 )
 
 func TestRegisterViperOIDCFlagsSingleProvider(t *testing.T) {

--- a/ginjwt/jwt.go
+++ b/ginjwt/jwt.go
@@ -13,7 +13,7 @@ import (
 	"gopkg.in/go-jose/go-jose.v2"
 	"gopkg.in/go-jose/go-jose.v2/jwt"
 
-	"go.hollow.sh/toolbox/ginauth"
+	"github.com/metal-toolbox/hollow-toolbox/ginauth"
 )
 
 const (

--- a/ginjwt/jwt_test.go
+++ b/ginjwt/jwt_test.go
@@ -17,8 +17,8 @@ import (
 	"gopkg.in/go-jose/go-jose.v2"
 	"gopkg.in/go-jose/go-jose.v2/jwt"
 
-	"go.hollow.sh/toolbox/ginauth"
-	"go.hollow.sh/toolbox/ginjwt"
+	"github.com/metal-toolbox/hollow-toolbox/ginauth"
+	"github.com/metal-toolbox/hollow-toolbox/ginjwt"
 )
 
 func TestMiddlewareValidatesTokensWithScopes(t *testing.T) {

--- a/ginjwt/multitokenmiddleware.go
+++ b/ginjwt/multitokenmiddleware.go
@@ -3,7 +3,7 @@ package ginjwt
 import (
 	"github.com/pkg/errors"
 
-	"go.hollow.sh/toolbox/ginauth"
+	"github.com/metal-toolbox/hollow-toolbox/ginauth"
 )
 
 // NewMultiTokenMiddlewareFromConfigs builds a MultiTokenMiddleware object from multiple AuthConfigs.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module go.hollow.sh/toolbox
+module github.com/metal-toolbox/hollow-toolbox
 
 go 1.26
 

--- a/rootcmd/options.go
+++ b/rootcmd/options.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"go.hollow.sh/toolbox/version"
+	"github.com/metal-toolbox/hollow-toolbox/version"
 
 	"go.uber.org/zap"
 )


### PR DESCRIPTION
This pull request updates the module path in `go.mod`.

- Changed the module path in `go.mod` from `go.hollow.sh/toolbox` to `github.com/metal-toolbox/hollow-toolbox`